### PR TITLE
Replace quill editor with tinyMCE in RichTextInput

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "ISC",
 			"dependencies": {
 				"@reduxjs/toolkit": "^1.6.2",
+				"@tinymce/tinymce-react": "^3.13.0",
 				"react-accessible-dropdown-menu-hook": "^3.1.0",
 				"react-beautiful-dnd": "^13.1.0",
 				"react-modal": "^3.14.4",
@@ -12394,6 +12395,19 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
+			}
+		},
+		"node_modules/@tinymce/tinymce-react": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-3.13.0.tgz",
+			"integrity": "sha512-8+OHYIUP9W5D5z7gknausaG48ovQtEvjcK4c+zpha7QppRVVX0ltaINpo10V6Vb4qj9Jf7ZFfZpMRxxcFL2YvQ==",
+			"dependencies": {
+				"prop-types": "^15.6.2",
+				"tinymce": "^5.5.1"
+			},
+			"peerDependencies": {
+				"react": "^17.0.1 || ^16.7.0",
+				"react-dom": "^17.0.1 || ^16.7.0"
 			}
 		},
 		"node_modules/@tootallnate/once": {
@@ -33960,6 +33974,11 @@
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
 			"integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
 		},
+		"node_modules/tinymce": {
+			"version": "5.10.3",
+			"resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.3.tgz",
+			"integrity": "sha512-O59ssHNnujWvSk5Gt8hIGrdNCMKVWVQv9F8siAgLTRgTh0t3NDHrP1UlLtCxArUi9DPWZvlBeUz8D5fJTu7vnA=="
+		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -45915,6 +45934,15 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.12.5"
+			}
+		},
+		"@tinymce/tinymce-react": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-3.13.0.tgz",
+			"integrity": "sha512-8+OHYIUP9W5D5z7gknausaG48ovQtEvjcK4c+zpha7QppRVVX0ltaINpo10V6Vb4qj9Jf7ZFfZpMRxxcFL2YvQ==",
+			"requires": {
+				"prop-types": "^15.6.2",
+				"tinymce": "^5.5.1"
 			}
 		},
 		"@tootallnate/once": {
@@ -62514,6 +62542,11 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
 			"integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+		},
+		"tinymce": {
+			"version": "5.10.3",
+			"resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.3.tgz",
+			"integrity": "sha512-O59ssHNnujWvSk5Gt8hIGrdNCMKVWVQv9F8siAgLTRgTh0t3NDHrP1UlLtCxArUi9DPWZvlBeUz8D5fJTu7vnA=="
 		},
 		"tmpl": {
 			"version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
 	},
 	"dependencies": {
 		"@reduxjs/toolkit": "^1.6.2",
+		"@tinymce/tinymce-react": "^3.13.0",
 		"react-accessible-dropdown-menu-hook": "^3.1.0",
 		"react-beautiful-dnd": "^13.1.0",
 		"react-modal": "^3.14.4",
-		"react-quill": "^2.0.0-beta.4",
 		"react-redux": "^7.2.6"
 	},
 	"devDependencies": {

--- a/src/components/Inputs/RichTextInput/__tests__/index.js
+++ b/src/components/Inputs/RichTextInput/__tests__/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { renderWithProvider } from '../../../../test-utils.js';
-// import { axe, toHaveNoViolations } from 'jest-axe';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
 import RichTextInput from '..';
 
-// expect.extend( toHaveNoViolations );
+expect.extend( toHaveNoViolations );
 
 it( 'should render sucessfully', () => {
 	const { container } = renderWithProvider(
@@ -14,7 +15,7 @@ it( 'should render sucessfully', () => {
 				onChange={ ( e ) => null }
 			/>
 		),
-		editor = container.querySelector( 'div.ql-editor' );
+		editor = container.querySelector( 'div.mce-content-body' );
 
 	expect( editor ).toContainHTML( 'This is an editor instance' );
 } );
@@ -28,7 +29,7 @@ it( 'should set initial value correctly', () => {
 				onChange={ ( e ) => null }
 			/>
 		),
-		editor = container.querySelector( '.ql-editor' );
+		editor = container.querySelector( '.mce-content-body' );
 	expect( editor ).toHaveTextContent( 'This is an editor instance.' );
 } );
 
@@ -62,36 +63,34 @@ it( 'should visually hide label when labelHidden is set', () => {
 	expect( label ).toHaveClass( 'show-for-sr' );
 } );
 //TODO: the react-quill editor does not pass a11y tests, may need to replace with another library
-// it( 'should not have basic accessibility issues', async () => {
-// 	const { container } = renderWithProvider(
-// 			<RichTextInput
-// 				name="pageContent"
-// 				value="This is an editor instance."
-// 				label="Content:"
-// 				onChange={ ( e ) => null }
-// 			/>
-// 		),
-// 		results = await axe( container );
-// 	expect( results ).toHaveNoViolations();
-// } );
+it( 'should not have basic accessibility issues', async () => {
+	const { container } = renderWithProvider(
+			<RichTextInput
+				name="pageContent"
+				value="This is an editor instance."
+				label="Content:"
+				onChange={ ( e ) => null }
+			/>
+		),
+		results = await axe( container );
+	expect( results ).toHaveNoViolations();
+} );
 
-//TODO: This would be a nivce feature to add, but don't need right now since the quill editor may be replaced anyway
-// it( 'should render the toolbar passed in', () => {
-// 	const { container } = renderWithProvider(
-// 			<RichTextInput
-// 				name="pageContent"
-// 				value="This is an editor instance."
-// 				label="Content:"
-// 				onChange={ ( e ) => null }
-// 				toolbar={ [ [ 'underline' ] ] }
-// 			/>
-// 		),
-// 		toolbar = container.querySelector( 'div.ql-toolbar' );
-
-// 	expect( toolbar ).toContainElement(
-// 		container.querySelector( 'button.ql-underline' )
-// 	);
-// 	expect( toolbar ).not.toContainElement(
-// 		container.querySelector( 'button.ql-italic' )
-// 	);
-// } );
+it( 'should render the toolbar passed in', async () => {
+	const { container } = renderWithProvider(
+		<RichTextInput
+			name="pageContent"
+			value="This is an editor instance."
+			label="Content:"
+			onChange={ ( e ) => null }
+			toolbar="bold"
+		/>
+	);
+	await new Promise( ( r ) => setTimeout( r, 1000 ) );
+	expect(
+		container.querySelector( 'button[title="Bold"]' )
+	).toBeInTheDocument();
+	expect(
+		container.querySelector( 'button[title="Italic"]' )
+	).not.toBeInTheDocument();
+} );

--- a/src/components/Inputs/RichTextInput/index.css
+++ b/src/components/Inputs/RichTextInput/index.css
@@ -1,0 +1,3 @@
+.tox-tinymce-inline {
+	z-index: 1000;
+}

--- a/src/components/Inputs/RichTextInput/index.js
+++ b/src/components/Inputs/RichTextInput/index.js
@@ -1,6 +1,28 @@
 import React from 'react';
-import ReactQuill from 'react-quill';
-import 'react-quill/dist/quill.snow.css';
+
+import { Editor } from '@tinymce/tinymce-react';
+
+// TinyMCE so the global var exists
+// eslint-disable-next-line no-unused-vars
+import tinymce from 'tinymce/tinymce';
+
+// Theme
+import 'tinymce/themes/silver';
+// Toolbar icons
+import 'tinymce/icons/default';
+// Editor styles
+import 'tinymce/skins/ui/oxide/skin.min.css';
+
+// importing the plugin js.
+import 'tinymce/plugins/link';
+import 'tinymce/plugins/autolink';
+import 'tinymce/plugins/lists';
+import 'tinymce/plugins/paste';
+
+import 'tinymce/plugins/quickbars';
+
+//Style overrides Override
+import './index.css';
 
 import { FieldLabel } from '../';
 
@@ -11,26 +33,46 @@ export function RichTextInput( {
 	label,
 	name,
 	value,
-	formats,
+	toolbar,
 	labelHidden,
 	helpText,
 	onChange,
 } ) {
 	const cssClasses = useSelector( selectCssClasses ),
-		defaultFormats = [ 'bold', 'italic', 'list', 'bullet', 'link' ];
+		defaultToolbar = [
+			'undo redo bold italic | bullist numlist | superscript subscript | removeformat',
+		];
 	return (
 		<React.Fragment>
 			<FieldLabel htmlFor={ name } visuallyHidden={ labelHidden }>
 				{ label }
 			</FieldLabel>
-			<CustomToolbar name={ name } />
-			<ReactQuill
-				value={ value || '' }
-				onChange={ onChange }
-				modules={ { toolbar: `#${ name }Toolbar` } }
-				formats={ formats || defaultFormats }
-				theme="snow"
-			/>
+			<div id="toolbar" style={ { height: '2em' } } />
+			<div style={ { padding: '0.5rem', border: '1px solid #757575' } }>
+				<Editor
+					init={ {
+						selector: 'textarea#default',
+						menubar: false,
+						inline: true,
+						skin: false,
+						browser_spellcheck: true,
+						contextmenu: false,
+						toolbar: toolbar || defaultToolbar,
+						fixed_toolbar_container: '#toolbar',
+						toolbar_persist: true,
+						plugins: 'quickbars link autolink lists paste',
+						link_context_toolbar: true,
+						link_quicklink: true,
+						link_title: false,
+						link_default_protocol: 'https',
+						quickbars_insert_toolbar: false,
+						quickbars_selection_toolbar: 'bold italic | quicklink',
+						valid_elements: 'p,ul,ol,li,strong,em,sup,sub,a[href]',
+					} }
+					onEditorChange={ onChange }
+					value={ value || '' }
+				/>
+			</div>
 			{ helpText && (
 				<span className={ cssClasses[ 'help-text' ] }>
 					{ ' ' }
@@ -38,43 +80,6 @@ export function RichTextInput( {
 				</span>
 			) }
 		</React.Fragment>
-	);
-}
-
-function CustomToolbar( { name } ) {
-	return (
-		<div id={ `${ name }Toolbar` }>
-			<span className="ql-formats">
-				<button className="ql-bold" aria-label="Bold"></button>
-				<button className="ql-italic" aria-label="Italics"></button>
-			</span>
-			<span className="ql-formats">
-				<button
-					className="ql-list"
-					value="ordered"
-					aria-label="Ordered List"
-				></button>
-				<button
-					className="ql-list"
-					value="bullet"
-					aria-label="Bulleted List"
-				></button>
-			</span>
-			<span className="ql-formats">
-				<button
-					className="ql-link"
-					type="button"
-					aria-label="Link"
-				></button>
-			</span>
-			<span className="ql-formats">
-				<button
-					className="ql-clean"
-					type="button"
-					aria-label="Clear Formatting"
-				></button>
-			</span>
-		</div>
 	);
 }
 export default RichTextInput;

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -14,3 +14,19 @@ export * from '@testing-library/react';
 
 // override render method
 export { renderWithProvider };
+
+// Add missing window.matchMedia mock needed by the rich text editor
+// https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+Object.defineProperty( window, 'matchMedia', {
+	writable: true,
+	value: jest.fn().mockImplementation( ( query ) => ( {
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: jest.fn(), // deprecated
+		removeListener: jest.fn(), // deprecated
+		addEventListener: jest.fn(),
+		removeEventListener: jest.fn(),
+		dispatchEvent: jest.fn(),
+	} ) ),
+} );


### PR DESCRIPTION
Quill is no longer active and has accessibility and security issues. Closes #1 